### PR TITLE
docs: multi-provider repos + repos.example.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,15 @@ reference, configuration, architecture, usage patterns, contributing.
 
 | Tool | Description |
 | ---- | ----------- |
-| `code_search` | Search symbols across .NET and TS |
+| `code_search` | Search symbols across all configured repos (.NET + TS) |
 | `code_get_api` | Public API of a type with signatures |
 | `code_get_graph` | Project/package dependency graph |
 | `code_list_branches` | Branches with committed code indexes |
+
+By default the code tools search two built-in repos (`granit-dotnet`,
+`granit-front`). Add **private GitHub** or **self-hosted GitLab** repos via a
+`repos.json` file — see
+[Configuration › additional repositories](docs/configuration.md#searching-additional-repositories).
 
 ### NuGet packages
 
@@ -59,6 +64,11 @@ dotnet tool install --global Granit.Tools.Mcp
 }
 ```
 
+For **private GitHub** or **self-hosted GitLab** repos, set
+`GRANIT_MCP_GITHUB_TOKEN` / `GRANIT_MCP_GITLAB_TOKEN` (+ `GRANIT_MCP_GITLAB_HOST`)
+in the server `env`, and list the repos in `~/.granit-mcp/repos.json` — see
+[Configuration](docs/configuration.md#searching-additional-repositories).
+
 ## Use with Cursor / Windsurf
 
 Add the MCP server in **Settings > MCP Servers**:
@@ -72,9 +82,10 @@ Add the MCP server in **Settings > MCP Servers**:
 Claude Code ──stdio──> Granit.Tools.Mcp (local .NET 10 tool)
                          |-- Docs ---------> SQLite FTS5
                          |                     ^ llms-full.txt (auto-generated)
-                         |-- Code ---------> .mcp-*-index.json (GitHub raw)
+                         |-- Code ---------> .mcp-*-index.json per repo
+                         |                     ^ via GitHub / GitLab APIs
                          |-- NuGet --------> api.nuget.org
-                         +-- Branches -----> api.github.com
+                         +-- Branches -----> GitHub / GitLab APIs
 ```
 
 ### Data sources
@@ -82,8 +93,7 @@ Claude Code ──stdio──> Granit.Tools.Mcp (local .NET 10 tool)
 | Source | Origin | Cache |
 | ------ | ------ | ----- |
 | Documentation | `granit-fx.dev/llms-full.txt` | SQLite (4h refresh) |
-| .NET code index | GitHub raw (branch-aware) | In-memory (12h) |
-| Front code index | GitHub raw (branch-aware) | In-memory (12h) |
+| Code indexes (per repo) | GitHub raw / Contents API / GitLab v4 (branch-aware) | In-memory (12h) |
 | NuGet packages | NuGet Search API | In-memory (12h) |
 | NuGet package info | NuGet Registration API | In-memory (6h) |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,9 +4,9 @@
 
 Granit Tools MCP is a local .NET 10 dotnet tool that speaks the
 [Model Context Protocol](https://modelcontextprotocol.io) over stdio.
-It acts as a bridge between AI assistants and three external data
-sources: the Granit documentation site, GitHub-hosted code indexes,
-and the NuGet registry.
+It acts as a bridge between AI assistants and external data sources:
+the Granit documentation site, per-repo code indexes (GitHub and
+self-hosted GitLab, public or private), and the NuGet registry.
 
 ```text
 AI assistant ──stdio (JSON-RPC)──> granit-tools-mcp
@@ -14,9 +14,8 @@ AI assistant ──stdio (JSON-RPC)──> granit-tools-mcp
                                      │    ↑ DocsIndexer        ↑ indexed from
                                      │    └─ periodic fetch ── granit-fx.dev/llms-full.txt
                                      │
-                                     ├─ CodeIndexClient ───> raw.githubusercontent.com
-                                     │    └─ branch-aware      .mcp-code-index.json
-                                     │                         .mcp-front-index.json
+                                     ├─ CodeIndexClient ───> per-repo .mcp-*-index.json
+                                     │    └─ branch-aware      GitHub / GitLab
                                      │
                                      ├─ NuGetClient ───────> api.nuget.org
                                      │    └─ optional ────────> nuget.pkg.github.com
@@ -86,11 +85,28 @@ refreshes on a configurable interval (`GRANIT_MCP_REFRESH_HOURS`).
 - The host is configured with `BackgroundServiceExceptionBehavior.Ignore`
   so a crash in the indexer never kills the server
 
+### RepoRegistry
+
+Builds the set of searchable repositories: the two built-in defaults
+(`granit-dotnet`, `granit-front`) plus any user-defined repos loaded from
+`repos.json` (`GRANIT_MCP_REPOS_FILE`). User entries augment the defaults
+and may override one by reusing its `id`. Each entry carries a `provider`
+(`github`/`gitlab`), `kind` (`dotnet`/`front`), `project`, and optional
+`host`/`indexPath`/`private`. Invalid entries are skipped with a warning.
+
 ### CodeIndexClient
 
-Fetches `.mcp-code-index.json` (for granit-dotnet) and
-`.mcp-front-index.json` (for granit-front) from GitHub raw URLs. The
-URL contains a `{branch}` placeholder that is replaced at runtime.
+Fetches each configured repo's `.mcp-*-index.json` and parses it per `kind`.
+The fetch endpoint and auth depend on the repo's `provider`:
+
+| Provider | Endpoint | Auth |
+| -------- | -------- | ---- |
+| GitHub (public) | `raw.githubusercontent.com` | none |
+| GitHub (`private`) | Contents API `api.github.com` | `Bearer GRANIT_MCP_GITHUB_TOKEN` |
+| GitLab | API v4 raw `https://{host}/api/v4/...` | `PRIVATE-TOKEN GRANIT_MCP_GITLAB_TOKEN` |
+
+Access is governed by the caller's token — a repo that returns 403/404 is
+skipped silently, so a team can share one `repos.json`.
 
 **Branch resolution:**
 
@@ -98,7 +114,7 @@ URL contains a `{branch}` placeholder that is replaced at runtime.
 2. Otherwise, call `GitBranchDetector.DetectBranch()` to read `.git/HEAD`
 3. If detection fails (not a git repo, detached HEAD), fall back to `develop`
 
-**Caching:** In-memory dictionary keyed by branch name, 12-hour TTL.
+**Caching:** In-memory dictionary keyed by `repo@branch`, 12-hour TTL.
 Returns stale data on network error.
 
 ### NuGetClient
@@ -145,6 +161,7 @@ All services are registered in `Program.cs`:
 GranitMcpConfig   → Singleton (immutable record from env vars)
 HttpClientFactory → Transient (via AddHttpClient)
 DocsStore         → Singleton (owns SQLite connection)
+RepoRegistry      → Singleton (defaults + repos.json)
 CodeIndexClient   → Singleton (owns in-memory cache)
 NuGetClient       → Singleton (owns in-memory cache)
 DocsIndexer       → HostedService (BackgroundService)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,6 +127,10 @@ and repos on a self-hosted GitLab — list them in `repos.json` (path from
 ]
 ```
 
+A ready-to-edit template with inline comments lives at
+[`repos.example.json`](../repos.example.json) in the repo root — copy it to
+`~/.granit-mcp/repos.json`. Comments (`//`) and trailing commas are allowed.
+
 ### Entry fields
 
 | Field | Required | Default | Notes |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,4 +89,6 @@ Try these in your AI assistant:
 
 - [Tools Reference](tools-reference.md) — complete reference for all nine tools
 - [Configuration](configuration.md) — environment variables, data directory, caching
+- [Private repos](configuration.md#searching-additional-repositories) —
+  add private GitHub / self-hosted GitLab repos via `repos.json`
 - [Architecture](architecture.md) — how the server works under the hood

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ navigation, and NuGet package discovery — via the Model Context Protocol.
 - [Tools Reference](tools-reference.md) — all 9 tools with parameters
   and examples
 - [Configuration](configuration.md) — environment variables, caching,
-  GitHub Packages
+  GitHub Packages, and adding private GitHub / GitLab repos
 - [Architecture](architecture.md) — system design, services, error
   handling
 - [Usage Patterns](usage-patterns.md) — practical workflows and tips

--- a/docs/usage-patterns.md
+++ b/docs/usage-patterns.md
@@ -70,6 +70,17 @@ code_search("MyNewType", branch="feature/new-module")
 → search against a specific branch
 ```
 
+### Search a private or extra repo
+
+```text
+code_search("InvoiceService", repo="business")
+→ search a repo configured in repos.json (private GitHub / GitLab)
+```
+
+Built-in repos (`dotnet`, `front`) are always available. Add more — including
+private GitHub or self-hosted GitLab repos — in `~/.granit-mcp/repos.json`; see
+[Configuration](configuration.md#searching-additional-repositories).
+
 ## NuGet: discovery and inspection
 
 ### List all packages

--- a/repos.example.json
+++ b/repos.example.json
@@ -1,0 +1,47 @@
+// Example repos.json for granit-tools-mcp.
+// Copy to ~/.granit-mcp/repos.json (or the path in GRANIT_MCP_REPOS_FILE),
+// then edit. Comments (//) and trailing commas are allowed.
+//
+// Each entry makes one repo searchable by the code tools, on top of the
+// built-in `dotnet` (granit-dotnet) and `front` (granit-front) repos.
+// Reuse an `id` to override a built-in.
+//
+// Fields:
+//   id        Selector for the `repo` tool parameter (default: last path segment)
+//   kind      "dotnet" | "front" — the index schema (required)
+//   provider  "github" (default) | "gitlab"
+//   project   GitHub "owner/name"; GitLab "group/subgroup/project" (required)
+//   host      GitLab host; falls back to GRANIT_MCP_GITLAB_HOST
+//   indexPath Defaults to .mcp-code-index.json / .mcp-front-index.json
+//   private   GitHub only — fetch via the authenticated Contents API
+//
+// Tokens go in the MCP server env (never in this file):
+//   GRANIT_MCP_GITHUB_TOKEN  Bearer token, for private GitHub repos
+//   GRANIT_MCP_GITLAB_TOKEN  PRIVATE-TOKEN, for GitLab repos
+[
+  // Private GitHub repo (Contents API + GRANIT_MCP_GITHUB_TOKEN)
+  {
+    "id": "business",
+    "kind": "dotnet",
+    "provider": "github",
+    "project": "granit-fx/granit-business",
+    "private": true
+  },
+
+  // Self-hosted GitLab repo; host inherited from GRANIT_MCP_GITLAB_HOST
+  {
+    "id": "internal-api",
+    "kind": "dotnet",
+    "provider": "gitlab",
+    "project": "granit/backend/internal-api"
+  },
+
+  // GitLab repo with an explicit host and a front (TypeScript) index
+  {
+    "id": "ops",
+    "kind": "front",
+    "provider": "gitlab",
+    "host": "gitlab.example.com",
+    "project": "infra/ops-console"
+  }
+]


### PR DESCRIPTION
## Summary

Post-1.1.0 docs follow-up: bring the README and `docs/` in line with the
dynamic multi-provider repo feature, and add a ready-to-edit
`repos.example.json` template.

## Changes

- **README** — code-tools note for private GitHub / self-hosted GitLab repos,
  updated architecture diagram + data-sources table, private-repo config hint.
- **docs/architecture.md** — new `RepoRegistry` service, multi-provider
  `CodeIndexClient` (endpoint/auth table, per-`repo@branch` cache), DI list.
- **docs/configuration.md** — link to the example template.
- **docs/getting-started.md**, **docs/index.md**, **docs/usage-patterns.md** —
  links + a "search a private/extra repo" pattern.
- **repos.example.json** — commented template (GitHub private + GitLab),
  copy to `~/.granit-mcp/repos.json`.

## Test plan

- `markdownlint-cli2` on README + docs — clean.
- `repos.example.json` parses under the loader's options (comments + trailing
  commas allowed).