### PR TITLE
chore: bump ModelContextProtocol to 1.4.0

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -2,13 +2,13 @@
 
 This project uses the following third-party packages.
 
-Dernière mise à jour : 2026-06-03
+Dernière mise à jour : 2026-06-08
 
 ## Summary
 
 | Package | Version | License | Copyright |
 | ------- | ------- | ------- | --------- |
-| ModelContextProtocol | 1.3.0 | MIT | Microsoft Corporation |
+| ModelContextProtocol | 1.4.0 | MIT | Microsoft Corporation |
 | Microsoft.Extensions.Hosting | 10.0.8 | MIT | Microsoft Corporation |
 | Microsoft.Extensions.Http | 10.0.8 | MIT | Microsoft Corporation |
 | Microsoft.Data.Sqlite | 10.0.8 | MIT | Microsoft Corporation |
@@ -16,7 +16,7 @@ Dernière mise à jour : 2026-06-03
 
 ## ModelContextProtocol
 
-- **Version:** 1.3.0
+- **Version:** 1.4.0
 - **License:** MIT
 - **Copyright:** Copyright (c) Microsoft Corporation
 - **Source:** <https://github.com/modelcontextprotocol/csharp-sdk>

--- a/src/Granit.Tools.Mcp/Granit.Tools.Mcp.csproj
+++ b/src/Granit.Tools.Mcp/Granit.Tools.Mcp.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />


### PR DESCRIPTION
## Summary

Bump the MCP SDK `ModelContextProtocol` from **1.3.0** to **1.4.0** (the only
outdated dependency), and sync `THIRD-PARTY-NOTICES.md`.

## Test plan

- `dotnet build -c Release` — 0 warnings, 0 errors.
- `dotnet test -c Release` — 27/27 passing.
- `dotnet list package --outdated` — clean.