### PR TITLE
chore: bump NuGet deps + fix SQLite transitive vulnerability (1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.1] - 2026-07-05
+
+### Security
+
+- Override transitive `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (high-severity
+  GHSA-2m69-gcr7-jv3q) pulled by Microsoft.Data.Sqlite with an explicit
+  `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 reference
+
+### Changed
+
+- Dependency updates: ModelContextProtocol 1.4.0, Microsoft.Extensions.\*
+  and Microsoft.Data.Sqlite 10.0.9, Markdig 1.3.2, Microsoft.NET.Test.Sdk
+  18.7.0
+
 ## [1.1.0] - 2026-06-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # granit-tools-mcp
 
-Local MCP server for the Granit framework. Distributed as a .NET 10
-dotnet tool. Provides documentation search (SQLite FTS5), code
-navigation, and NuGet package discovery via the Model Context Protocol.
+Local MCP server for the Granit framework, distributed as a .NET 10 dotnet tool.
+Provides documentation search (SQLite FTS5), code navigation, and NuGet package
+discovery via the Model Context Protocol.
 
 ## Stack
 
@@ -65,10 +65,10 @@ Environment variables with `GRANIT_MCP_` prefix:
 
 ### Additional repos (`repos.json`)
 
-Built-in repos `dotnet` (granit-dotnet) and `front` (granit-front) are
-always searchable. Add private GitHub or self-hosted GitLab repos via
-`repos.json` (augments defaults; reuse an `id` to override one). Access is
-governed by the caller's token — unreachable repos are skipped silently.
+Built-in repos `dotnet` (granit-dotnet) and `front` (granit-front) are always
+searchable. Add private GitHub or self-hosted GitLab repos via `repos.json`
+(augments defaults; reuse an `id` to override one). Access is governed by the
+caller's token — unreachable repos are skipped silently.
 
 ```jsonc
 [

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -2,17 +2,18 @@
 
 This project uses the following third-party packages.
 
-Dernière mise à jour : 2026-06-08
+Dernière mise à jour : 2026-07-05
 
 ## Summary
 
 | Package | Version | License | Copyright |
 | ------- | ------- | ------- | --------- |
 | ModelContextProtocol | 1.4.0 | MIT | Microsoft Corporation |
-| Microsoft.Extensions.Hosting | 10.0.8 | MIT | Microsoft Corporation |
-| Microsoft.Extensions.Http | 10.0.8 | MIT | Microsoft Corporation |
-| Microsoft.Data.Sqlite | 10.0.8 | MIT | Microsoft Corporation |
-| Markdig | 1.2.0 | BSD-2-Clause | Alexandre Mutel |
+| Microsoft.Extensions.Hosting | 10.0.9 | MIT | Microsoft Corporation |
+| Microsoft.Extensions.Http | 10.0.9 | MIT | Microsoft Corporation |
+| Microsoft.Data.Sqlite | 10.0.9 | MIT | Microsoft Corporation |
+| SQLitePCLRaw.bundle_e_sqlite3 | 3.0.3 | Apache-2.0 | Eric Sink / SourceGear |
+| Markdig | 1.3.2 | BSD-2-Clause | Alexandre Mutel |
 
 ## ModelContextProtocol
 
@@ -23,28 +24,37 @@ Dernière mise à jour : 2026-06-08
 
 ## Microsoft.Extensions.Hosting
 
-- **Version:** 10.0.8
+- **Version:** 10.0.9
 - **License:** MIT
 - **Copyright:** Copyright (c) .NET Foundation and Contributors
 - **Source:** <https://github.com/dotnet/runtime>
 
 ## Microsoft.Extensions.Http
 
-- **Version:** 10.0.8
+- **Version:** 10.0.9
 - **License:** MIT
 - **Copyright:** Copyright (c) .NET Foundation and Contributors
 - **Source:** <https://github.com/dotnet/runtime>
 
 ## Microsoft.Data.Sqlite
 
-- **Version:** 10.0.8
+- **Version:** 10.0.9
 - **License:** MIT
 - **Copyright:** Copyright (c) .NET Foundation and Contributors
 - **Source:** <https://github.com/dotnet/efcore>
 
+## SQLitePCLRaw.bundle_e_sqlite3
+
+- **Version:** 3.0.3
+- **License:** Apache-2.0
+- **Copyright:** Copyright (c) Eric Sink / SourceGear, LLC
+- **Source:** <https://github.com/ericsink/SQLitePCL.raw>
+- **Note:** Explicit reference overriding the vulnerable `SQLitePCLRaw.lib.e_sqlite3`
+  2.1.11 pulled transitively by Microsoft.Data.Sqlite (GHSA-2m69-gcr7-jv3q)
+
 ## Markdig
 
-- **Version:** 1.2.0
+- **Version:** 1.3.2
 - **License:** BSD-2-Clause
 - **Copyright:** Copyright (c) Alexandre Mutel
 - **Source:** <https://github.com/xoofx/markdig>

--- a/src/Granit.Tools.Mcp/Granit.Tools.Mcp.csproj
+++ b/src/Granit.Tools.Mcp/Granit.Tools.Mcp.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>granit-tools-mcp</ToolCommandName>
     <PackageId>Granit.Tools.Mcp</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Description>MCP server for the Granit framework — docs search (FTS5), code navigation, and NuGet package discovery</Description>
     <Authors>Jean-François Meyers</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -25,10 +25,12 @@
 
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
-    <PackageReference Include="Markdig" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- Override transitive SQLitePCLRaw.lib.e_sqlite3 2.1.11 (GHSA-2m69-gcr7-jv3q) pulled by Microsoft.Data.Sqlite -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="Markdig" Version="1.3.2" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Tools.Mcp.Tests/Granit.Tools.Mcp.Tests.csproj
+++ b/tests/Granit.Tools.Mcp.Tests/Granit.Tools.Mcp.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

Dependency refresh with a security fix, released as **1.1.1**.

### Security 🔒
- Microsoft.Data.Sqlite 10.0.9 still drags in `SQLitePCLRaw.lib.e_sqlite3` **2.1.11** transitively, flagged high severity ([GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q)) — `dotnet restore` failed with `NU1903`.
- Added an explicit `SQLitePCLRaw.bundle_e_sqlite3` **3.0.3** reference to override it with the fixed `lib.e_sqlite3` 3.50.x.

### Dependency updates
| Package | From | To |
| ------- | ---- | -- |
| Microsoft.Extensions.Hosting | 10.0.8 | 10.0.9 |
| Microsoft.Extensions.Http | 10.0.8 | 10.0.9 |
| Microsoft.Data.Sqlite | 10.0.8 | 10.0.9 |
| Markdig | 1.2.0 | 1.3.2 |
| Microsoft.NET.Test.Sdk | 18.6.0 | 18.7.0 |

### Housekeeping
- Package version `1.1.0` → `1.1.1`
- `CHANGELOG.md` and `THIRD-PARTY-NOTICES.md` updated (new SQLitePCLRaw entry, Apache-2.0)

## Verification
- `dotnet restore` — no `NU1903`, `e_sqlite3` resolves to 3.0.3
- `dotnet build -c Release` — 0 warning / 0 error
- `dotnet test` — **27 passed**
- `markdownlint-cli2` — clean